### PR TITLE
Fix torch.log() NaN Issue and deterministic torch algorithms

### DIFF
--- a/tools/modules/diffusions/schedules.py
+++ b/tools/modules/diffusions/schedules.py
@@ -78,14 +78,14 @@ def sigmas_to_betas(sigmas):
 
 def sigmas_to_logsnrs(sigmas):
     square_sigmas = sigmas**2
-    return torch.log(square_sigmas / (1 - square_sigmas))
+    return torch.log(torch.clamp(square_sigmas / (1 - square_sigmas), torch.finfo(square_sigmas.dtype).tiny))
 
 
 def _logsnr_cosine(n, logsnr_min=-15, logsnr_max=15):
     t_min = math.atan(math.exp(-0.5 * logsnr_min))
     t_max = math.atan(math.exp(-0.5 * logsnr_max))
     t = torch.linspace(1, 0, n)
-    logsnrs = -2 * torch.log(torch.tan(t_min + t * (t_max - t_min)))
+    logsnrs = -2 * torch.log(torch.clamp(torch.tan(t_min + t * (t_max - t_min)), torch.finfo(torch.float).tiny))
     return logsnrs
 
 

--- a/tools/modules/unet/util.py
+++ b/tools/modules/unet/util.py
@@ -280,7 +280,8 @@ class RelativePositionBias(nn.Module):
         is_small = n < max_exact
 
         val_if_large = max_exact + (
-            torch.log(n.float() / max_exact) / math.log(max_distance / max_exact) * (num_buckets - max_exact)
+            torch.log(torch.clamp(n.float() / max_exact, torch.finfo(torch.float).tiny))
+            / math.log(max_distance / max_exact) * (num_buckets - max_exact)
         ).long()
         val_if_large = torch.min(val_if_large, torch.full_like(val_if_large, num_buckets - 1))
 

--- a/utils/seed.py
+++ b/utils/seed.py
@@ -9,3 +9,4 @@ def setup_seed(seed):
      np.random.seed(seed)
      random.seed(seed)
      torch.backends.cudnn.deterministic = True
+     torch.use_deterministic_algorithms(True)


### PR DESCRIPTION
Dear i2vgen-xl contributors,

I've taken the initiative to address and resolve several linting warnings pointed out by a pylint plugin called dslinter. The code suggestions that it gave were:

1. **torch.log() Variable Clamping:**
   - Enclosed the variable in the torch.log() operation with torch.clamp() to establish a minimum value. This modification ensures a safeguard against potential NaN errors, particularly when the input variable is exceptionally small.
   - Before:
     ```python
     result = torch.log(input_var)
     ```
   - After:
     ```python
     result = torch.log(torch.clamp(input_var, min=torch.finfo(input_var.dtype).tiny))
     ```
2. **deterministic pytorch algorithms:**
   - I added ```torch.use_deterministic_algorithms(True)``` to the seed.py file, this forces pytorch to use deterministic algorithms, making the code more reproducable [pytorch documentation](https://pytorch.org/docs/stable/notes/randomness.html#avoiding-nondeterministic-algorithms)

I invite your valuable insights and feedback on these modifications to guarantee that they align seamlessly with our shared coding standards and project requirements.