### PR TITLE
fix the invalid 'revision' parameter in the pipeline and optimize save video

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -6,7 +6,7 @@ import gradio as gr
 from modelscope.pipelines import pipeline
 from modelscope.outputs import OutputKeys
 
-image_to_video_pipe = pipeline(task="image-to-video", model='damo/i2vgen-xl', revision='v1.1.3', device='cuda:0')
+image_to_video_pipe = pipeline(task="image-to-video", model='damo/i2vgen-xl', model_revision='v1.1.3', device='cuda:0')
 
 def upload_file(file):
     return file.name

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ triton==2.0.0.dev20221120
 pytorch-lightning==1.4.2
 torchmetrics==0.6.0
 gradio==3.39.0
+imageio-ffmpeg

--- a/utils/video_op.py
+++ b/utils/video_op.py
@@ -194,17 +194,13 @@ def save_i2vgen_video_safe(
                 local_path = local_path + '.png'
                 cv2.imwrite(local_path, images[0][:,:,::-1], [int(cv2.IMWRITE_JPEG_QUALITY), 100])
             else:
-                frame_dir = os.path.join(os.path.dirname(local_path), '%s_frames' % (os.path.basename(local_path)))
-                os.system(f'rm -rf {frame_dir}'); os.makedirs(frame_dir, exist_ok=True)
+                writer = imageio.get_writer(local_path, fps=save_fps, codec='libx264', quality=8)
                 for fid, frame in enumerate(images):
                     if fid == num_image-1: # Fix known bugs.
                         ratio = (np.sum((frame >= 117) & (frame <= 137)))/(frame.size)
                         if ratio > 0.4: continue
-                    tpth = os.path.join(frame_dir, '%04d.png' % (fid+1))
-                    cv2.imwrite(tpth, frame[:,:,::-1], [int(cv2.IMWRITE_JPEG_QUALITY), 100])
-                cmd = f'ffmpeg -y -f image2 -loglevel quiet -framerate {save_fps} -i {frame_dir}/%04d.png -vcodec libx264 -crf 17  -pix_fmt yuv420p {local_path}'
-                os.system(cmd) 
-                os.system(f'rm -rf {frame_dir}')
+                    writer.append_data(frame)
+                writer.close()
             break
         except Exception as e:
             exception = e


### PR DESCRIPTION
When I run gradio_app.py, I get a message that doesn't look normal:
```
2024-01-10 18:08:07,177 - modelscope - WARNING - Model revision should be specified from revisions: [v1.1.4,v1.1.3,v1.1.2,v1.1.1,v1.1.0,v1.0.0]
2024-01-10 18:08:07,177 - modelscope - WARNING - Model revision not specified, use revision: master
```
After reading the source code of modelscope and verifying them, I found that the 'revision' parameter used in the gradio_app.py pipeline is incorrect. This parameter is invalid and should be replaced with 'model_revision', refer to [modelscope](https://github.com/modelscope/modelscope/blob/master/modelscope/pipelines/builder.py#L76).

In addition, when I saved the generated video, some exceptions occurred due to ffmpeg environment issues on the system. I think it would be a better option to switch from using the ffmpeg command to using Python's imageio library for saving the video, as this would make it less dependent on the operating system.